### PR TITLE
ShareBook button styling and starter text for share with url

### DIFF
--- a/src/util/styles/CopyLinkButton.module.scss
+++ b/src/util/styles/CopyLinkButton.module.scss
@@ -18,6 +18,7 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
+	cursor: pointer;
 
 	&:focus {
 		outline: 0;

--- a/src/util/styles/CopyLinkButton.module.scss
+++ b/src/util/styles/CopyLinkButton.module.scss
@@ -18,4 +18,8 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
+
+	&:focus {
+		outline: 0;
+	}
 }

--- a/src/views/books/components/ShareBook.js
+++ b/src/views/books/components/ShareBook.js
@@ -18,13 +18,13 @@ function ShareBook(props) {
   return (
     <div className={styles.btnContainer}>
       <CopyLinkButton />
-      <FacebookShareButton url={shareUrl} className="icon-button">
+      <FacebookShareButton url={shareUrl} className={styles.iconBtn}>
         <FacebookIcon size={32} round={true} />
       </FacebookShareButton>
-      <TwitterShareButton url={shareUrl} className="icon-button">
+      <TwitterShareButton url={shareUrl} className={styles.iconBtn}>
         <TwitterIcon size={32} round={true} />
       </TwitterShareButton>
-      <EmailShareButton url={shareUrl} className="icon-button">
+      <EmailShareButton url={shareUrl} className={styles.iconBtn}>
         <EmailIcon size={32} round={true} />
       </EmailShareButton>
       <div className="sms-icon-button">

--- a/src/views/books/components/ShareBook.js
+++ b/src/views/books/components/ShareBook.js
@@ -14,17 +14,19 @@ import styles from '../styles/ShareBook.module.scss';
 
 function ShareBook(props) {
   const shareUrl = `${process.env.REACT_APP_MESSENGER_URL}?ref=book_id=${props.book_id}`;
-
+  const socialQuote = 'Check out this book on ChatWise';
+  const emailSubject = 'A book I thought you would like';
+  const emailBody = 'I found this book on ChatWise and I think you might like it. You can read a quick summary right in the ChatWise messenger!';
   return (
     <div className={styles.btnContainer}>
       <CopyLinkButton />
-      <FacebookShareButton url={shareUrl} className={styles.iconBtn}>
+      <FacebookShareButton url={shareUrl} quote={socialQuote} className={styles.iconBtn}>
         <FacebookIcon size={32} round={true} />
       </FacebookShareButton>
-      <TwitterShareButton url={shareUrl} className={styles.iconBtn}>
+      <TwitterShareButton url={shareUrl} title={socialQuote} className={styles.iconBtn}>
         <TwitterIcon size={32} round={true} />
       </TwitterShareButton>
-      <EmailShareButton url={shareUrl} className={styles.iconBtn}>
+      <EmailShareButton url={shareUrl} subject={emailSubject} body={emailBody} className={styles.iconBtn}>
         <EmailIcon size={32} round={true} />
       </EmailShareButton>
       <div className="sms-icon-button">

--- a/src/views/books/styles/ShareBook.module.scss
+++ b/src/views/books/styles/ShareBook.module.scss
@@ -25,6 +25,8 @@
 	// }
 
 	.iconBtn {
+		cursor: pointer;
+
 		&:focus {
 			outline: 0;
 		}

--- a/src/views/books/styles/ShareBook.module.scss
+++ b/src/views/books/styles/ShareBook.module.scss
@@ -13,15 +13,23 @@
 		justify-content: space-between;
 		margin-right: 10px;
 	}
-	.icon-button {
-		margin: 3px;
-		@include phone-portrait {
-			display: flex;
-			flex-flow: row;
-			width: 150px;
-			height: 40px;
+
+	// .icon-button {
+	// 	margin: 3px;
+	// 	@include phone-portrait {
+	// 		display: flex;
+	// 		flex-flow: row;
+	// 		width: 150px;
+	// 		height: 40px;
+	// 	}
+	// }
+
+	.iconBtn {
+		&:focus {
+			outline: 0;
 		}
 	}
+
 	.sms-icon-button {
 		margin: 3px;
 	}


### PR DESCRIPTION
# Description

- styling changes to share buttons (removed focus square on click, curser:pointer on hover)
- Used props on react-share buttons to pass in starter text (e.g., 'title' for tweet share, 'subject' and 'body' for email share)
- NOTE: The FacebookShareButton receives a 'quote' prop, which is added to the facebook.com/sharer/sharer.php url (the url of the facebook sharing popup) but the quote is not inserted in the body of the facebook post. This seems to be an issue with react-share and/or the facebook sharing feature.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Manually tested

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts